### PR TITLE
Support RSpec 3.8

### DIFF
--- a/lib/paraspec/version.rb
+++ b/lib/paraspec/version.rb
@@ -1,3 +1,3 @@
 module Paraspec
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/paraspec.gemspec
+++ b/paraspec.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "paraspec"
-  s.version     = "0.0.2"
+  s.version     = "0.0.3"
   s.platform    = Gem::Platform::RUBY
   s.license     = "MIT"
   s.authors     = ["Oleg Pudeyev"]
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_path     = "lib"
 
   s.required_ruby_version = '>= 1.9.3'
-  s.add_runtime_dependency "rspec-core", "~> 3.7.1"
+  s.add_runtime_dependency "rspec-core", ">= 3.7.1", "< 4.0"
   s.add_runtime_dependency "childprocess", "~> 0.9.0"
   s.add_runtime_dependency "hashie", "~> 3.5.7"
   s.add_runtime_dependency "msgpack", "~> 1.2.4"


### PR DESCRIPTION
Hi, first of all thanks for this :bowing_man:, `paraspec` is a bowl of fresh air after `parallel_test`.
The version lock are quite restrictives though and only allows `rspec 3.7.x` which is unfortunate, I guess you wanted to be safe and avoid incompatibilities? Anyway I just upgraded to `rspec 3.8.2` to benefit from some bugfixes and was sad to no be able to use `paraspec` any more so I tried loosening the version check to anything after `3.7.1` but before `4.0` (which is less restrictive but still pretty safe to avoid `4.0` breaking changes) and it works perfectly fine with `rspec 3.8.2` for me so here's the MR if you're interested :tada: 