### PR TITLE
Loosen msgpack, hashie and childprocess dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'childprocess'
   gem 'rspec_junit_formatter'
   gem 'nokogiri'
   gem 'fuubar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,8 @@ PATH
   remote: .
   specs:
     paraspec (0.0.3)
-      childprocess (~> 0.9.0)
-      hashie (~> 3.5.7)
-      msgpack (~> 1.2.4)
+      hashie (>= 3.4.5)
+      msgpack
       rspec-core (>= 3.7.1, < 4.0)
 
 GEM
@@ -18,9 +17,9 @@ GEM
     fuubar (2.5.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
-    hashie (3.5.7)
+    hashie (4.1.0)
     mini_portile2 (2.4.0)
-    msgpack (1.2.10)
+    msgpack (1.4.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     rspec (3.9.0)
@@ -45,6 +44,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  childprocess
   fuubar
   nokogiri
   paraspec!

--- a/paraspec.gemspec
+++ b/paraspec.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
   s.add_runtime_dependency "rspec-core", ">= 3.7.1", "< 4.0"
-  s.add_runtime_dependency "childprocess", "~> 0.9.0"
-  s.add_runtime_dependency "hashie", "~> 3.5.7"
-  s.add_runtime_dependency "msgpack", "~> 1.2.4"
+  s.add_runtime_dependency "hashie", ">= 3.4.5"
+  s.add_runtime_dependency "msgpack"
 end


### PR DESCRIPTION
Hey :wave: 

It's me again trying to loosen some dependencies as `paraspec` is prevent upgrade across the apps ☺

1. First with `msgpack`, the latest versions of bootsnap require `1.3+` but paraspec locks at `1.2` so I tried loosening and it worked fine up to the latest `1.4.1`, I also tried going to lower versions (down to ~0.7) and it still worked fine. So I'm guessing there's no real reason to restrict this one and I removed the version constraint so people are free to use the version their project requires. If you know of any strong requirements here we can add them back.
2. Then with `hashie`, I tried latest version which works fine, I then tried going down and noticed it stopped working bellow `3.4.5` so I change the constraint to `>= 3.4.5` here.
3. Finally `childprocess` doesn't seem to be needed at all by the gem, it's only used in the specs, so I removed this one from the gem dependencies and moved it to the `Gemfile` instead.

This should make `paraspec` more compatible with various projects (and even a bit lighter to install) ;)
Let me know what you think! (and if you want me to bump the version also)

---

Edit: Oh and just the confirmation that specs are green in this branch:
```
desktop [paraspec] (loosen-dependencies) > rspec
 55/55 |====================== 100 =======================>| Time: 00:01:20 

Finished in 1 minute 20.12 seconds (files took 0.12293 seconds to load)
55 examples, 0 failures
```